### PR TITLE
Added Casper verbose logging configuration to sheut.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Sheut [![NPM version](http://img.shields.io/npm/v/sheut.svg)](https://www.npmjs.
  
 ## sheut.config.js 
 
+ * `debug` : Boolean to determine if Casper's verbose logging is enabled
  * `server` : (optional) If provided Sheut will start a static server using the dir and port given. If omitted, Sheut will assume the server has already been started.
    * `dir`: The location of the site to serve.
    * `port`: the port to open the server on.

--- a/casper.js
+++ b/casper.js
@@ -26,6 +26,11 @@ function createImageName(site, selector, viewport){
     return slugize(site) + '_' + slugize(selector) + '_' + slugize(viewport) + '.png'
 }
 
+if (config.debug) {
+    casper.options.verbose = true;
+    casper.options.logLevel = "debug";
+}
+
 casper.start().each(urls, function(self, link) {
     var site = sites[link];
 
@@ -43,23 +48,24 @@ casper.start().each(urls, function(self, link) {
             //});
             //this.then(function(){
             this.then(function(){
-                this.each(site.hideSelectors, function(self, selector){
-                    this.evaluate(function() {
-                        var elsToHide = document.querySelectorAll('.skycon');
-                        for (var el in elsToHide){
-                            elsToHide[el].setAttribute('style','visibility:hidden');
-                        }
+                if (site.hideSelectors) {
+                    this.each(site.hideSelectors, function(self, selector){
+                        this.evaluate(function() {
+                            var elsToHide = document.querySelectorAll('.skycon');
+                            for (var el in elsToHide){
+                                elsToHide[el].setAttribute('style','visibility:hidden');
+                            }
+                        });
                     });
-                });
+                }
 
                 this.each(site.selectors, function(self, selector){
-
                     self.waitForSelector(selector, (function() {
                         imageToCapture = createImageName(site.name, selector, viewport.name);
                         console.log("Saved screenshot " + imageToCapture);
                         self.captureSelector(paths.new + '/' + imageToCapture, selector);
                     }), (function() {
-                        self.die("Timeout reached. Fail whale?");
+                        self.die('Timeout reached. Try setting the debug property in the Sheut config to true to determine the problem.');
                         self.exit();
                     }), 12000);
                 });

--- a/sheut.config.js
+++ b/sheut.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-    server : {
+    debug: false,
+    server: {
         dir: '_site',
         port: 8888
     },


### PR DESCRIPTION
Developers can specify a `debug` boolean in `sheut.config.js` to enable CasperJS's vebose logging.
