### PR TITLE
Added waitForSelector property to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Sheut [![NPM version](http://img.shields.io/npm/v/sheut.svg)](https://www.npmjs.
 ## sheut.config.js 
 
  * `debug` : (optional) Boolean to determine if Casper's verbose logging is enabled
+ * `waitForSelector` : (optional) waits for a CSS selector to be attached to a DOM element before capturing each screenshot. Could be useful if you're waiting for JavaScript to update elements in your page.
  * `server` : (optional) If provided Sheut will start a static server using the dir and port given. If omitted, Sheut will assume the server has already been started.
    * `dir`: The location of the site to serve.
    * `port`: the port to open the server on.

--- a/casper.js
+++ b/casper.js
@@ -42,36 +42,33 @@ casper.start().each(urls, function(self, link) {
 
         this.thenOpen(link, function() {
 
-            //may need to do this if site has JS changing the page on load.
-            //    better to hook into browser events or something
-            //    this.wait(5000);
-            //});
-            //this.then(function(){
-            this.then(function(){
-                if (site.hideSelectors) {
-                    this.each(site.hideSelectors, function(self, selector){
-                        this.evaluate(function(selector) {
-                            var elsToHide = document.querySelectorAll(selector);
-                            for (var el in elsToHide) {
-                                elsToHide[el].setAttribute('style','visibility:hidden');
-                            }
-                        }, selector);
-                    });
-                }
+            this.waitForSelector(config.waitForSelector || 'html', function() {
+                this.then(function(){
+                    if (site.hideSelectors) {
+                        this.each(site.hideSelectors, function(self, selector){
+                            this.evaluate(function(selector) {
+                                var elsToHide = document.querySelectorAll(selector);
+                                for (var el in elsToHide) {
+                                    elsToHide[el].setAttribute('style','visibility:hidden');
+                                }
+                            }, selector);
+                        });
+                    }
 
-                self.each(site.selectors, function(self, selector) {
-                    self.waitForSelector(selector, (function() {
-                        if (self.getElementInfo(selector).visible) {
-                            imageToCapture = createImageName(site.name, selector, viewport.name);
-                            console.log("Saved screenshot", imageToCapture);
-                            self.captureSelector(paths.new + '/' + imageToCapture, selector);
-                        } else {
-                            console.warn(selector, 'on', site.name, 'isn\'t visible at', viewport.width, 'x', viewport.height, 'so no image has been captured');
-                        }
-                    }), (function() {
-                        self.die('Timeout reached. Try setting the debug property in the Sheut config to true to determine the problem.');
-                        self.exit();
-                    }), 12000);
+                    self.each(site.selectors, function(self, selector) {
+                        self.waitForSelector(selector, (function() {
+                            if (self.getElementInfo(selector).visible) {
+                                imageToCapture = createImageName(site.name, selector, viewport.name);
+                                console.log("Saved screenshot", imageToCapture);
+                                self.captureSelector(paths.new + '/' + imageToCapture, selector);
+                            } else {
+                                console.warn(selector, 'on', site.name, 'isn\'t visible at', viewport.width, 'x', viewport.height, 'so no image has been captured');
+                            }
+                        }), (function() {
+                            self.die('Timeout reached. Try setting the debug property in the Sheut config to true to determine the problem.');
+                            self.exit();
+                        }), 12000);
+                    });
                 });
             });
         });


### PR DESCRIPTION
The config block can now take a parameter named 'waitForSelector' to instruct the screenshot to only be done after this selector becomes available on the page.
This is especially useful if you need to wait for elements to be loaded by JavaScript before taking the screenshots.
