### PR TITLE
No references warning.

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,10 +118,18 @@ function imageErrors(file, data){
 
 function compare(){
     return findFiles(paths.reference).then(function(files){
-        var promises = [];
-        var file_list = files.split('\n');
+        
+        if (!files || !files.length) {
+            console.error('No references were found to compare the new screenshots to. Please accept the previously generated screenshots with `Sheut.accept()`');
+            process.exit(1);
+        }
+
+        var promises = [],
+            file_list = files.split('\n');
+
         file_list.shift();
         file_list.pop();
+
         file_list.forEach(function(file){
             promises.push(compareAndSaveDifference(file));
         });


### PR DESCRIPTION
Adding a warning and exit when no reference screenshots are available to compare with.
The previous version was simply saying all was fine, which is misleading.
