### PR TITLE
Updating Canvas dependency to the one with the correct Cairo method calls. 1.2.0 was failing on OSX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site/
 node_modules/
 npm-debug.log
 *.iml
+.DS_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
-  
+
+## 0.0.12
+
+ * Updated canvas dependency to target 1.2.1, which does not fail to install on OSX
+
 ## 0.0.11
 
  * Added `waitForSelector` option to allow people to wait for any potential js changes to take affect.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "paths"
   ],
   "dependencies": {
-    "canvas": "^1.1.6",
+    "canvas": "^1.2.1",
     "casper": "^0.1.1",
     "chalk": "^0.5.1",
     "del": "^1.1.1",


### PR DESCRIPTION
See issue:
https://github.com/Automattic/node-canvas/issues/509

And fix pull request:
https://github.com/Automattic/node-canvas/pull/511
