### PR TITLE
Orphaned references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.13
+
+ * Added filtering of files: if reference files exist but no comparison file is present in the 'new' directory, the compare method now doesn't error out. Instead, it shows which files are 'orphaned' and continues on.
+
 ## 0.0.12
 
  * Updated canvas dependency to target 1.2.1, which does not fail to install on OSX

--- a/casper.js
+++ b/casper.js
@@ -13,9 +13,9 @@ var urls = config.sites.map(function(site){
 });
 
 var paths = {
-    new: config.screenshots + '/new',
-    different: config.screenshots + '/different',
-    reference: config.screenshots + '/reference'
+    new: config.screenshotsRoot + '/new',
+    different: config.screenshotsRoot + '/different',
+    reference: config.screenshotsRoot + '/reference'
 };
 
 function slugize(name){

--- a/index.js
+++ b/index.js
@@ -1,42 +1,55 @@
+/*jslint node: true */
+/* global console, require, process, module */
+
 'use strict';
-var Promise = require('es6-promise').Promise;
 var findup = require('findup-sync');
-var gutil = require('gulp-util');
-var casperPath = findup('node_modules/sheut/casper.js');
 var configPath = findup('./sheut.config.js');
 if (!configPath) {
     console.log('Please add a sheut.config.js file in your root.');
     process.exit(1);
 }
 
+var Promise = require('es6-promise').Promise;
+var gutil = require('gulp-util');
+var chalk = require('chalk');
+var casperPath = findup('node_modules/sheut/casper.js');
 var config = require(configPath);
 var mkdirp = require('mkdirp');
 var del = require('del');
+var path = require('path');
 var fs = require('fs');
 var fse = require('fs-extra');
-var child_process = require('child_process');
-var spawn = child_process.spawn;
-var exec = child_process.exec;
-var execFile = child_process.execFile;
 var resemble = require('./wrappers/resemble');
 var nodeCasper = require('./wrappers/casper');
 var staticServer = require('./wrappers/server');
+
 var paths = {
-    new: config.screenshots + '/new',
-    different: config.screenshots + '/different',
-    reference: config.screenshots + '/reference'
+    new: path.join(config.screenshotsRoot, 'new'),
+    different: path.join(config.screenshotsRoot, 'different'),
+    reference: path.join(config.screenshotsRoot, 'reference')
 };
 var thresholds = config.thresholds || { };
 
+// If a server config is given,
+//  this will run it.
+// That's mainly for testing purposes,
+//  as your own application will rely
+//  on its own server
 function serve(server){
-    if (!server) return;
+    if (!server) {
+        return;
+    }
+
     return staticServer.start(server.dir, server.port);
 }
 
 function capture(){
     var testServer = serve(config.server);
-    return nodeCasper([casperPath || './casper.js', '--configPath=' + configPath]).then(function closeServer(){
-        testServer && testServer.close();
+    return nodeCasper([casperPath || './casper.js', '--configPath=' + configPath]).then(function closeServer() {
+        if (testServer) {
+            testServer.close();
+        }
+
         return {message: 'Sheut: Images Captured'};
     });
 }
@@ -44,25 +57,50 @@ function capture(){
 function accept(){
     return new Promise(function(resolve, reject){
         fse.copy(paths.new, paths.reference, function(err){
-            if (err) return reject(err);
+            if (err) {
+                return reject(err);
+            }
+
             resolve({message: 'Sheut: Images Accepted as reference shots'});
-        })
-    });
-}
-
-
-function clean(){
-    return new Promise(function(resolve, reject){
-        del([paths.new, paths.different], function(){
-            resolve({message: 'Sheut: New and Different Images removed'})
         });
     });
 }
 
-function findFiles(dir){
+function clean(){
     return new Promise(function(resolve, reject){
-        execFile('find', [ dir ], function(err, stdout, stderr) {
-            resolve(stdout);
+        del([paths.new, paths.different], function(){
+            resolve({message: 'Sheut: New and Different Images removed'});
+        });
+    });
+}
+
+function filterFiles(dir){
+    return new Promise(function(resolve, reject){
+        fs.readdir(dir, function (err, files) {
+
+            var filteredFiles = {
+                validFiles: [],
+                orphanedFiles: []
+            };
+
+            var newFile;
+
+            files.forEach(function(fileName){
+
+                if(fileName.match(/\.DS*/)) {
+                    return;
+                }
+
+                try {
+                    newFile = fs.readFileSync(path.join(paths.new, fileName));
+                    filteredFiles.validFiles.push(fileName);
+
+                } catch (e) {
+                    filteredFiles.orphanedFiles.push(fileName);
+                }
+            });
+
+            resolve(filteredFiles);
         });
     });
 }
@@ -72,22 +110,25 @@ function saveDifference(file, data){
         mkdirp(paths.different, function saveFile(){
             var base64 = data.getImageDataUrl().replace(/^data:image\/png;base64,/, "");
             fs.writeFile(file, base64, {encoding:'base64'}, function(){
-                resolve()
+                resolve();
             });
         });
     });
 }
 
-function compareAndSaveDifference(file){
+function compareAndSaveDifference(fileName){
     return new Promise(function(resolve, reject){
-        var img1 = fs.readFileSync(file);
-        var img2 = fs.readFileSync(file.replace('/reference/', '/new/'));
-        var imgDiff = file.replace('/reference/', '/different/');
-        var api = resemble(img2).compareTo(img1).onComplete(function(data){
-            var errors = imageErrors(imgDiff, data);
+
+        var diffFilePath = path.join(paths.different, fileName);
+        var referenceFile = fs.readFileSync(path.join(paths.reference, fileName));
+        var newFile = fs.readFileSync(path.join(paths.new, fileName));
+
+        var api = resemble(newFile).compareTo(referenceFile).onComplete(function(data){
+            var errors = imageErrors(diffFilePath, data);
+
             if (errors.length){
-                saveDifference(imgDiff, data).then(function(){
-                    var err = new gutil.PluginError('Sheut: ', errors.join('\n'), {showStack: false})
+                saveDifference(diffFilePath, data).then(function(){
+                    var err = new gutil.PluginError('Sheut: ', errors.join('\n'), {showStack: false});
                     reject(err);
                 });
             } else {
@@ -103,38 +144,45 @@ function imageErrors(file, data){
         if (data.dimensionDifference.width !== (thresholds.width || 0)) {
             errors.push('the new image is wider/smaller: ' + data.dimensionDifference.width + 'px different');
         }
+
         if (data.dimensionDifference.height !== (thresholds.height || 0)) {
             errors.push('the new image is taller/smaller: ' + data.dimensionDifference.height + 'px different');
         }
-        errors.push(file)
+
+        errors.push(file);
     }
+
     if (data.misMatchPercentage > (thresholds.misMatchPercentage || 0)) {
         errors.push('The new image content has changed: ' + data.misMatchPercentage + '% different');
-        errors.push(file)
+        errors.push(file);
     }
+
     return errors;
 }
 
-
 function compare(){
-    return findFiles(paths.reference).then(function(files){
-        
-        if (!files || !files.length) {
-            console.error('No references were found to compare the new screenshots to. Please accept the previously generated screenshots with `Sheut.accept()`');
+    return filterFiles(paths.reference).then(function(files){
+
+        if (!files.validFiles.length) {
+            gutil.log(chalk.red('Sheut: No references were found to compare the new screenshots to. Please accept the previously generated screenshots with `Sheut.accept()`'));
             process.exit(1);
         }
 
-        var promises = [],
-            file_list = files.split('\n');
+        if (files.orphanedFiles.length) {
+            gutil.log(chalk.yellow('/!\\/!\\ Sheut: The following files are orphaned (a reference exists, but new screenshots aren\'t being captured with the current configuration)\n', files.orphanedFiles));
+        }
 
-        file_list.shift();
-        file_list.pop();
+        var promises = [];
 
-        file_list.forEach(function(file){
-            promises.push(compareAndSaveDifference(file));
+        files.validFiles.forEach(function(fileName){
+            gutil.log(chalk.cyan('Comparing ' + fileName));
+            promises.push(compareAndSaveDifference(fileName));
         });
 
-        return Promise.all(promises).then(function(){ return {message: 'Sheut: New images match reference shots'}; });
+        return Promise.all(promises)
+            .then(function(data) {
+                return {message: 'Sheut: New images match reference shots'};
+            });
     });
 }
 

--- a/sheut.config.js
+++ b/sheut.config.js
@@ -24,7 +24,7 @@ module.exports = {
 
     // directory under which all screenshots
     //  are taken and compared.
-    screenshots: './test/screenshots/',
+    screenshotsRoot: './test/screenshots/',
 
     // set here all the viewports you will
     //  need to screenshot. A screenshot


### PR DESCRIPTION
If reference files exist, but no corresponding file has been captured, Sheut now reports then as orphaned, but doesn't error out anymore
