### PR TITLE
Globally-hidden selectors and ignored viewports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,27 @@ Sheut [![NPM version](http://img.shields.io/npm/v/sheut.svg)](https://www.npmjs.
  
 ## sheut.config.js 
 
- * `debug` : (optional) Boolean to determine if Casper's verbose logging is enabled
- * `waitForSelector` : (optional) waits for a CSS selector to be attached to a DOM element before capturing each screenshot. Could be useful if you're waiting for JavaScript to update elements in your page.
- * `server` : (optional) If provided Sheut will start a static server using the dir and port given. If omitted, Sheut will assume the server has already been started.
-   * `dir`: The location of the site to serve.
-   * `port`: the port to open the server on.
- * `thresholds` : (optional) When making comparison, how much difference is allowed before an error is reported.
-   * `misMatchPercentage` : (default 0) 
-   * `height` : (default 0)
-   * `width` :  (default 0)
- * `screenshots` : (mandatory) The directory where to save the captured screens.
- * `viewport` : (mandatory) An array of sizes to test the give sites at.
-   * `name` : Used to categorise the url and used in the filename of the save screen-shots.
-   * `height` : The height of the browser.
-   * `width` : The width of the browser.
- * `sites` : (mandatory) An array of URLs to test.
-   * `name` : Used to categorise the url and used in the filename of the save screen-shots.
-   * `url` : The url to test
-   * `hideSelectors` : An array of selectors to hide (visibility:hidden)
-   * `selectors` : An array of selectors to take test.  Saved screenshots will be trimmed to show only this selector.
+ * `debug`: (optional) Boolean to determine if Casper's verbose logging is enabled
+ * `waitForSelector`: (optional) waits for a CSS selector to be attached to a DOM element before capturing each screenshot. Could be useful if you're waiting for JavaScript to update elements in your page
+ * `server`: (optional) If provided Sheut will start a static server using the dir and port given. If omitted, Sheut will assume the server has already been started
+   * `dir`: The location of the site to serve
+   * `port`: the port on which to open the server
+ * `thresholds`: (optional) When making comparison, how much difference is allowed before an error is reported.
+   * `misMatchPercentage`: (default 0) 
+   * `height`: (default 0)
+   * `width`:  (default 0)
+ * `screenshots`: (mandatory) The directory where to save the captured screens.
+ * `hideSelectors`: An array of selectors to be hidden in **all** tests (visibility: hidden)
+ * `viewports`: (mandatory) An array of resolutions at which to test the sites
+   * `name`: Used to categorise the url and used in the filename of the save screenshots
+   * `height`: The height of the browser.
+   * `width`: The width of the browser.
+ * `sites`: (mandatory) An array of URLs to test.
+   * `name`: Used to categorise the url and used in the filename of the save screenshots
+   * `url`: The url to test
+   * `hideSelectors`: An array of selectors to be hidden (visibility: hidden)
+   * `selectors`: An array of selectors to take test. Saved screenshots will be trimmed to show only this selector
+   * `ignoredViewports`: An array of viewport names that will be skipped for this test. If not specified, this test will run against all viewports
 
 ## NPM Example
 
@@ -50,11 +52,11 @@ Add the following to your package.json and run `npm test`
 {
 ...
   "scripts":{
-    "sheut:capture" : "sheut capture",
-    "sheut:accept" : "sheut accept",
-    "sheut:clean" : "sheut clean",
-    "sheut:compare" : "sheut compare",
-    "test" : "sheut clean && sheut capture && sheut compare"
+    "sheut:capture": "sheut capture",
+    "sheut:accept": "sheut accept",
+    "sheut:clean": "sheut clean",
+    "sheut:compare": "sheut compare",
+    "test": "sheut clean && sheut capture && sheut compare"
   }
 }
 ```

--- a/_site/index.html
+++ b/_site/index.html
@@ -41,6 +41,10 @@
 					<h3>Akh ((magically) effective one')</h3>
 					Ancient Egyptians believed that death occurs when a person's ka leaves the body. Ceremonies conducted by priests after death, including the "opening of the mouth", aimed not only to restore a person's physical abilities in death, but also to release a Ba's attachment to the body. This allowed the Ba to be united with the Ka in the afterlife, creating an entity known as an "Akh".
 				</div>
+
+				<div class="hide-me-globally">
+					I should not appear in any tests, bro.
+				</div>
 			</div>
 
 			<a href="http://en.wikipedia.org/wiki/Ancient_Egyptian_concept_of_the_soul">Source: Wikipedia</a>

--- a/_site/index.html
+++ b/_site/index.html
@@ -25,6 +25,10 @@
 			<p>A person's shadow or silhouette, Sheut (šwt in Egyptian), is always present. Because of this, Egyptians surmised that a shadow contains something of the person it represents. Through this association, statues of people and deities were sometimes referred to as shadows.</p>
 
 			<p>The shadow was also representative to Egyptians of a figure of death, or servant of Anubis, and was depicted graphically as a small human figure painted completely black. Sometimes people (usually pharaohs) had a shadow box in which part of their Sheut was stored.</p>
+
+			<div class="hide-me-globally">
+				I should not appear in any tests, bro.
+			</div>
 		</div>
 		<div class="container-2">
 			<h2>Other soul elements</h2>
@@ -40,10 +44,6 @@
 				<div class="hide-me-from-sheut">
 					<h3>Akh ((magically) effective one')</h3>
 					Ancient Egyptians believed that death occurs when a person's ka leaves the body. Ceremonies conducted by priests after death, including the "opening of the mouth", aimed not only to restore a person's physical abilities in death, but also to release a Ba's attachment to the body. This allowed the Ba to be united with the Ka in the afterlife, creating an entity known as an "Akh".
-				</div>
-
-				<div class="hide-me-globally">
-					I should not appear in any tests, bro.
 				</div>
 			</div>
 

--- a/casper.js
+++ b/casper.js
@@ -35,9 +35,9 @@ casper.start().each(urls, function(self, link) {
     var site = sites[link];
     var viewports = config.viewports;
 
-    if (site.viewports) {
+    if (site.ignoredViewports) {
         viewports = config.viewports.filter(function (viewport) {
-            return site.viewports.indexOf(viewport.name) > -1;
+            return site.ignoredViewports.indexOf(viewport.name) === -1;
         });
     }
 
@@ -51,16 +51,20 @@ casper.start().each(urls, function(self, link) {
 
             this.waitForSelector(config.waitForSelector || 'html', function() {
                 this.then(function(){
+                    var hideSelectors = config.hideSelectors || [];
+
                     if (site.hideSelectors) {
-                        this.each(site.hideSelectors, function(self, selector){
-                            this.evaluate(function(selector) {
-                                var elsToHide = document.querySelectorAll(selector);
-                                for (var el in elsToHide) {
-                                    elsToHide[el].setAttribute('style','visibility:hidden');
-                                }
-                            }, selector);
-                        });
+                        hideSelectors = hideSelectors.concat(site.hideSelectors);
                     }
+                    
+                    this.each(hideSelectors, function(self, selector) {
+                        this.evaluate(function(selector) {
+                            var elsToHide = document.querySelectorAll(selector);
+                            for (var el in elsToHide) {
+                                elsToHide[el].setAttribute('style','visibility:hidden');
+                            }
+                        }, selector);
+                    });
 
                     self.each(site.selectors, function(self, selector) {
                         self.waitForSelector(selector, (function() {

--- a/casper.js
+++ b/casper.js
@@ -23,7 +23,7 @@ function slugize(name){
 }
 
 function createImageName(site, selector, viewport){
-    return slugize(site) + '_' + slugize(selector) + '_' + slugize(viewport) + '.png'
+    return slugize(site) + '_' + slugize(selector) + '_' + slugize(viewport) + '.png';
 }
 
 if (config.debug) {
@@ -33,8 +33,15 @@ if (config.debug) {
 
 casper.start().each(urls, function(self, link) {
     var site = sites[link];
+    var viewports = config.viewports;
 
-    self.each(config.viewports, function(self, viewport){
+    if (site.viewports) {
+        viewports = config.viewports.filter(function (viewport) {
+            return site.viewports.indexOf(viewport.name) > -1;
+        });
+    }
+
+    self.each(viewports, function(self, viewport){
 
         this.then(function() {
             this.viewport(viewport.width, viewport.height);

--- a/index.js
+++ b/index.js
@@ -17,7 +17,11 @@ var Promise = require('es6-promise').Promise,
 
 
 var Sheut = function(configFilePath) {
-    this.configPath = configFilePath || findup('sheut.config.js');
+    this.configPath = findup('sheut.config.js');
+
+    if (!this.configPath) {
+        this.configPath = path.join(process.cwd(), configFilePath);
+    }
 
     if (!fs.existsSync(this.configPath)) {
         console.log('Please add a sheut.config.js file in your root.');

--- a/index.js
+++ b/index.js
@@ -17,11 +17,7 @@ var Promise = require('es6-promise').Promise,
 
 
 var Sheut = function(configFilePath) {
-    if (!configFilePath) {
-        this.configPath = findup('sheut.config.js');
-    }
-
-    this.configPath = path.join(process.cwd(),configFilePath);
+    this.configPath = configFilePath || findup('sheut.config.js');
 
     if (!fs.existsSync(this.configPath)) {
         console.log('Please add a sheut.config.js file in your root.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sheut",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Take and Compare screenshots",
   "main": "index.js",
   "keywords": [],

--- a/sheut.config.js
+++ b/sheut.config.js
@@ -56,6 +56,13 @@ module.exports = {
         }
     ],
 
+    // Add here selectors that would be hidden
+    // with 'visibility: hidden' before capturing
+    // these apply to all sites in the test suite
+    'hideSelectors': [
+        '.hide-me-globally'
+    ],
+
     // An array of sites to capture screenshots from
     sites : [
         {
@@ -63,7 +70,8 @@ module.exports = {
             'url':'http://localhost:8888',
 
             // Add here selectors that would be hidden
-            //  with 'display: none' before capturing
+            //  with 'visibility: hidden' before capturing
+            // this applys solely to this test
             'hideSelectors': [
                 '.hide-me-from-sheut'
             ],
@@ -72,6 +80,35 @@ module.exports = {
             'selectors':[
                 '.container-1',
                 '.container-2 .nested'
+            ],
+
+            // determine the viewports against which this test
+            // should run. If this property isn't specified,
+            // the test will be run against all of the
+            // viewports above.
+            viewports: [
+                'phone',
+                'tablet_p'
+            ]
+        },
+        {
+            'name':'localhost',
+            'url':'http://localhost:8888/page2',
+
+
+            // Add here selectors for elements to be captured
+            'selectors':[
+                '.container-1',
+                '.container-2 .nested'
+            ],
+
+            // determine the viewports against which this test
+            // should run. If this property isn't specified,
+            // the test will be run against all of the
+            // viewports above.
+            viewports: [
+                'tablet_l',
+                'desktop'
             ]
         },
         {

--- a/sheut.config.js
+++ b/sheut.config.js
@@ -59,7 +59,7 @@ module.exports = {
     // Add here selectors that would be hidden
     // with 'visibility: hidden' before capturing
     // these apply to all sites in the test suite
-    'hideSelectors': [
+    hideSelectors: [
         '.hide-me-globally'
     ],
 
@@ -82,33 +82,29 @@ module.exports = {
                 '.container-2 .nested'
             ],
 
-            // determine the viewports against which this test
-            // should run. If this property isn't specified,
-            // the test will be run against all of the
-            // viewports above.
-            viewports: [
-                'phone',
-                'tablet_p'
+            // determine which viewports are ignored
+            // in this test
+            ignoredViewports: [
+                'tablet_l',
+                'desktop'
             ]
         },
         {
-            'name':'localhost',
-            'url':'http://localhost:8888/page2',
-
+            'name':'page two',
+            'url':'http://localhost:8888/page2.html',
 
             // Add here selectors for elements to be captured
             'selectors':[
-                '.container-1',
-                '.container-2 .nested'
+                '.container-1'
             ],
 
             // determine the viewports against which this test
             // should run. If this property isn't specified,
             // the test will be run against all of the
             // viewports above.
-            viewports: [
-                'tablet_l',
-                'desktop'
+            ignoredViewports: [
+                'tablet_p',
+                'phone'
             ]
         },
         {

--- a/wrappers/server/index.js
+++ b/wrappers/server/index.js
@@ -13,8 +13,8 @@ function start(dir, port){
         var done = finalhandler(req, res);
         serve(req, res, function onNext(err) {
             if (err) return done(err);
-            index(req, res, done)
-        })
+            index(req, res, done);
+        });
     });
     server.listen(port);
     return server;


### PR DESCRIPTION
Hi,

I've extended the Sheut config with two new properties:
- `hideSelectors` (at the config root): an array of selectors to be hidden in **all** tests
- `ignoredViewports` (within a `site` object): an array of viewport names that will be skipped for a respective test

These changes have been tested against the Sheut repo itself and the Sky News website. The README has been updated accordingly.
