### PR TITLE
@df Peg canvas dependency to 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "paths"
   ],
   "dependencies": {
-    "canvas": "^1.2.1",
+    "canvas": "1.2.3",
     "casper": "^0.1.1",
     "chalk": "^0.5.1",
     "del": "^1.1.1",


### PR DESCRIPTION
Canvas 1.2.4 fails to compile on Linux. Temporarily pegging to 1.2.3 to work around.
